### PR TITLE
Toy mandelbrot image (numba @jit example)

### DIFF
--- a/genesis/toys/mandel.py
+++ b/genesis/toys/mandel.py
@@ -1,0 +1,48 @@
+# http://numba.pydata.org/numba-doc/latest/user/examples.html
+
+import matplotlib.pyplot as plt
+import numpy as np
+from numba import jit
+
+
+@jit
+def mandel(x, y, max_iters):
+    i = 0
+    c = complex(x, y)
+    z = 0.0j
+
+    for i in range(max_iters):
+        z = z * z + c
+
+        if z.real * z.real + z.imag * z.imag >= 4:
+            return i
+
+    return 255
+
+
+@jit
+def create_fractal(min_x, max_x, min_y, max_y, image, iters):
+    height, width = image.shape
+
+    pixel_size_x = (max_x - min_x) / width
+    pixel_size_y = (max_y - min_y) / height
+
+    for x in range(width):
+        real = min_x + x * pixel_size_x
+
+        for y in range(height):
+            imag = min_y + y * pixel_size_y
+
+            color = mandel(real, imag, iters)
+            image[y, x] = color
+
+    return image
+
+
+if __name__ == "__main__":
+    image = np.zeros((500 * 2, 750 * 2), dtype=np.uint8)
+    create_fractal(-2.0, 1.0, -1.0, 1.0, image, 20)
+
+    plt.jet()
+    plt.imshow(image)
+    plt.show()

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setuptools.setup(
         "matplotlib",
         "mypy",
         "numpy~=1.18.1",
+        "numba",
         "pandas",
         "scipy",
         "seaborn",


### PR DESCRIPTION
From https://numba.pydata.org:

> Numba is an open source JIT compiler that translates a subset of Python and NumPy code into fast machine code.

Numba is likely to come in handy for speeding up computation of otherwise unoptimized code. Since some of this project's code will be written for the sake of learning and understanding and not computational efficiency, it might be nice to be able to leverage some of Numba's functionality without otherwise changing the code.